### PR TITLE
upload zip file for releases as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,38 +1,36 @@
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  release:
+    types: # This configuration does not affect the page_build event above
+      - created
 
-name: Upload Release Asset
+name: Upload Release Assets
 
 jobs:
   build:
-    name: Upload Release Asset
+    name: Upload Release Assets
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Build project # This would actually build your project, using zip for an example artifact
+      - name: Create Tar and Zip File
         run: |
           tar -czvf JuliaMono.tar.gz JuliaMono-*.ttf LICENSE
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset 
+          zip JuliaMono.zip JuliaMono-*.ttf LICENSE
+      - name: Upload Tar File
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./JuliaMono.tar.gz
           asset_name: JuliaMono.tar.gz
           asset_content_type: application/tar+gzip
+      - name: Upload Zip File
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./JuliaMono.zip
+          asset_name: JuliaMono.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This also changes the way the action is triggered, so you can just create a release through the GitHub UI, instead of having to only create a tag manually on the command line. If you prefer to do releases like you did before instead, I can also change that back.
closes #38