### PR TITLE
Update the instructions for installing on Mac using Homebrew

### DIFF
--- a/website/__site/download/index.html
+++ b/website/__site/download/index.html
@@ -30,7 +30,7 @@
 <h5 id="homebrew"><a href="#homebrew">Homebrew</a></h5>
 <p>On the latest version of Homebrew, you can install the fonts with:</p>
 <pre><code class="language-julia">&#36; brew tap homebrew/cask-fonts
-&#36; brew cask install font-juliamono</code></pre>
+&#36; brew install --cask font-juliamono</code></pre>
 <h4 id="windows"><a href="#windows">Windows</a></h4>
 <p>To install and activate a font on Windows, go to Computer |&gt; Local Disk &#40;C:&#41; |&gt; Windows |&gt; Fonts. Locate the expanded .zip file folder, and drag the font files from there into the Fonts folder.</p>
 <h4 id="linux_-_using_font_manager"><a href="#linux_-_using_font_manager">Linux - using Font Manager</a></h4>


### PR DESCRIPTION
Running `brew cask install font-juliamono` gives me the following warning:
```
Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
```

This PR changes the instructions to instead recommend `brew cask install font-juliamono`.