### PR TITLE
Add a font-face CSS files for webfonts

### DIFF
--- a/webfonts/juliamono-regular.css
+++ b/webfonts/juliamono-regular.css
@@ -1,0 +1,5 @@
+@font-face {
+    font-family: JuliaMono;
+    src: url("JuliaMono-Regular.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}

--- a/webfonts/juliamono.css
+++ b/webfonts/juliamono.css
@@ -1,0 +1,55 @@
+@font-face {
+    font-family: JuliaMono;
+    font-weight: 300;
+    font-style: normal;
+    src: url("JuliaMono-Light.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}
+
+@font-face {
+    font-family: JuliaMono;
+    font-weight: 400;
+    font-style: normal;
+    src: url("JuliaMono-Regular.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}
+
+@font-face {
+    font-family: JuliaMono;
+    font-weight: 500;
+    font-style: normal;
+    src: url("JuliaMono-Medium.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}
+
+@font-face {
+    font-family: JuliaMono;
+    font-weight: 600;
+    font-style: normal;
+    src: url("JuliaMono-SemiBold.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}
+
+@font-face {
+    font-family: JuliaMono;
+    font-weight: 700;
+    font-style: normal;
+    src: url("JuliaMono-Bold.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}
+
+@font-face {
+    font-family: JuliaMono;
+    font-weight: 800;
+    font-style: normal;
+    src: url("JuliaMono-ExtraBold.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}
+
+@font-face {
+    font-family: JuliaMono;
+    font-weight: 900;
+    font-style: normal;
+    src: url("JuliaMono-Black.woff2") format("woff2");
+    text-rendering: optimizeLegibility;
+}


### PR DESCRIPTION
So that you could load the fonts from cdnjs by just loading a single CSS file (for https://github.com/JuliaDocs/Documenter.jl/pull/1569). I created two variants -- one loads just the regular font and the other one loads `.woff2` files for all the different thicknesses.

I guess the cdnjs configuration would also need to be updated before tagging since it is currently not including CSS files? 